### PR TITLE
correctly initialize a fresh database

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,8 +63,8 @@ build ()
 
     if [ $REM -eq 1 ]; then
         rm $OUTPUT > /dev/null 2>&1
-        sqlite3 $OUTPUT < schema.sql
     fi
+    sqlite3 $OUTPUT < schema.sql
 
     suffix=_reading
 


### PR DESCRIPTION
The current code incorrectly handles the case when the database does not exist. It fails to create the database schema. It only creates the schema when the "--remove" flag is passed, but this shouldn't be necessary when the database does not exist, as there is nothing to remove.

This PR addresses the issue.